### PR TITLE
UI/UX (nav): split profile avatar from settings in primary nav

### DIFF
--- a/src/app/components/PrimaryNav.svelte
+++ b/src/app/components/PrimaryNav.svelte
@@ -3,7 +3,8 @@
   import {page} from "$app/stores"
   import {goto} from "$app/navigation"
   import {splitAt} from "@welshman/lib"
-  import {userProfile} from "@welshman/app"
+  import {userProfile, pubkey} from "@welshman/app"
+  import ProfileDetail from "@app/components/ProfileDetail.svelte"
   import Widget from "@assets/icons/widget.svg?dataurl"
   import Compass from "@assets/icons/compass.svg?dataurl"
   import Letter from "@assets/icons/letter.svg?dataurl"
@@ -36,6 +37,10 @@
   const {children}: Props = $props()
 
   const spaceUrls = $derived($userSpaceUrls)
+
+  const openProfile = () => {
+    if ($pubkey) pushModal(ProfileDetail, {pubkey: $pubkey})
+  }
 
   const showOtherSpacesMenu = () => pushModal(MenuOtherSpaces, {urls: secondarySpaceUrls})
 
@@ -158,34 +163,29 @@
     {/if}
     <div>
       <div class="hidden md:block lg:hidden">
-        <PrimaryNavItem
-          title="Settings"
-          href="/settings"
-          prefix="/settings"
-          class="tooltip-right">
+        <PrimaryNavItem title="Profile" onclick={openProfile} class="tooltip-right">
           {#if $userProfile?.picture}
             <img
-              alt="Settings"
+              alt="Profile"
               src={$userProfile.picture}
               class="h-7 w-7 min-h-7 min-w-7 rounded-full object-cover" />
           {:else}
-            <ImageIcon alt="Settings" src={UserRounded} size={7} class="rounded-full" />
+            <ImageIcon alt="Profile" src={UserRounded} size={7} class="rounded-full" />
           {/if}
         </PrimaryNavItem>
       </div>
       <div class="hidden lg:block">
         <PrimaryNavItem
-          title="Settings"
-          href="/settings/profile"
-          prefix="/settings"
+          title="Profile"
+          onclick={openProfile}
           class="tooltip-right">
           {#if $userProfile?.picture}
             <img
-              alt="Settings"
+              alt="Profile"
               src={$userProfile.picture}
               class="h-7 w-7 min-h-7 min-w-7 rounded-full object-cover" />
           {:else}
-            <ImageIcon alt="Settings" src={UserRounded} size={7} class="rounded-full" />
+            <ImageIcon alt="Profile" src={UserRounded} size={7} class="rounded-full" />
           {/if}
         </PrimaryNavItem>
       </div>
@@ -220,6 +220,15 @@
         </PrimaryNavItem>
       {/each}
       <SlotRenderer slotId="space:sidebar:widgets" context={{urls: spaceUrls}} />
+      <div class="hidden md:block">
+        <PrimaryNavItem
+          title="Settings"
+          href="/settings/profile"
+          prefix="/settings"
+          class="tooltip-right">
+          <ImageIcon alt="Settings" src={Settings} size={7} />
+        </PrimaryNavItem>
+      </div>
     </div>
   </div>
 </div>
@@ -259,14 +268,7 @@
       </PrimaryNavItem>
     {/if}
     <PrimaryNavItem compact title="Settings" onclick={showSettingsMenu}>
-      {#if $userProfile?.picture}
-        <img
-          alt="Settings"
-          src={$userProfile.picture}
-          class="h-9 w-9 min-h-9 min-w-9 rounded-full object-cover" />
-      {:else}
-        <ImageIcon alt="Settings" src={Settings} size={9} class="rounded-full" />
-      {/if}
+      <ImageIcon alt="Settings" src={Settings} size={5} />
     </PrimaryNavItem>
   </div>
 </div>


### PR DESCRIPTION
I found the profile icon leading to settings quite unintuitive. I think splitting makes sense. Hope you like it.

I think having a dedicated profile page for self and especially others where you can view someone's repo's would be good. but would be more work.

<img width="329" height="422" alt="Screenshot 2026-04-21 at 16 03 03" src="https://github.com/user-attachments/assets/64dbe483-4372-4ed7-8ee6-1d0cbae8f227" />

<img width="379" height="284" alt="Screenshot 2026-04-21 at 16 04 50" src="https://github.com/user-attachments/assets/b7532a4a-5e1b-4f4c-b5aa-ca80db295be8" />


---

## Summary
- The user avatar in the left nav rail used to double as the Settings entry. Split into two items: **Profile** (avatar → opens the user's `ProfileDetail` modal) and **Settings** (gear icon, moved to the bottom of the desktop rail).
- Mobile bottom bar keeps only Settings to avoid crowding; the Settings icon there now matches the size of its siblings.
- Currently a self-profile page doesn't exist in the app — profiles are modals only — so the Profile button opens the same `ProfileDetail` modal that clicking a user's name elsewhere would.

## Test plan
- [ ] Desktop (≥md): avatar at top of rail opens the profile modal; gear at the bottom opens `/settings/profile`
- [ ] `lg` viewport behaves the same as `md` for these entries
- [ ] Mobile bottom bar: single Settings entry opens the settings menu modal
- [ ] Existing settings pages still mark the gear active (`prefix=\"/settings\"`)