### PR TITLE
Fix submodule remote url in main repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ GoogleService-Info.plist
 # IDEs and editors
 .idea/
 .vscode/
+**/*.sw[op]
 
 # OS generated
 .DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,4 +14,4 @@
 	url = https://github.com/chebizarro/budabit-kanban-extension.git
 [submodule "packages/budabit-pipelines-extension"]
 	path = packages/budabit-pipelines-extension
-	url = https://github.com/chebizarro/budabit-pipelines-extension.git
+	url = https://github.com/Pleb5/budabit-pipelines-extension.git


### PR DESCRIPTION
make budabit consistent again.

My guess is that the development will be going on in the Pleb5/budabit-pipelines-extension repo from now on.

If I am right:
Can I get push rights for it as a developer on the project?